### PR TITLE
Update validator.ttl to allow literals for schema:license (2.1.13)

### DIFF
--- a/validators/validator.ttl
+++ b/validators/validator.ttl
@@ -224,7 +224,6 @@ BASE <https://linked.data.gov.au/def/vocpub/validator/>
     sh:property [
         sh:message "Requirement 2.1.13 Any licence pertaining to the reuse of a vocabulary's content SHOULD be given using the schema:license predicate preferentially indicating the IRI of a license if in RDF form or a literal URL (datatype xsd:anyURI) if online but not in RDF form. If the licence is expressed in text, a literal text field may be indicated" ;
         sh:path schema:license ;
-        sh:nodeKind sh:IRI ;
         sh:or (
             [ sh:nodeKind sh:IRI ]
             [ sh:datatype xsd:anyURI ]


### PR DESCRIPTION
Removing sh:nodeKind sh:IRI ;

... which seems to override the literal options and in any case is redundant as it's included in the sh:or